### PR TITLE
Resources metadata editor and layout broken if poc and/or metadata_author are missing

### DIFF
--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -1397,6 +1397,15 @@ class ResourceBase(PolymorphicModel, PermissionLevelMixin, ItemBase):
             self.is_approved = False
             self.is_published = False
 
+    def add_missing_metadata_author_or_poc(self):
+        """
+        Set metadata_author and/or point of contact (poc) to a resource when any of them is missing
+        """
+        if not self.metadata_author:
+            self.metadata_author = self.owner
+        if not self.poc:
+            self.poc = self.owner
+
     metadata_author = property(_get_metadata_author, _set_metadata_author)
 
     objects = ResourceBaseManager()

--- a/geonode/base/tests.py
+++ b/geonode/base/tests.py
@@ -49,6 +49,20 @@ class ThumbnailTests(GeoNodeBaseTestSupport):
         self.assertTrue('missing_thumb' in os.path.splitext(missing)[0])
 
 
+class TestCreationOfMissingMetadataAuthorsOrPOC(ThumbnailTests):
+
+    def test_add_missing_metadata_author_or_poc(self):
+        """
+        Test that calling add_missing_metadata_author_or_poc resource method sets
+        a missing metadata_author and/or point of contact (poc) to resource owner
+        """
+        user = get_user_model().objects.create(username='zlatan_i')
+        self.rb.owner = user
+        self.rb.add_missing_metadata_author_or_poc()
+        self.assertEqual(self.rb.metadata_author.username, 'zlatan_i')
+        self.assertEqual(self.rb.poc.username, 'zlatan_i')
+
+
 class RenderMenuTagTest(GeoNodeBaseTestSupport):
     """
     Test class for render_menu and render_top_menu custom tags of base_tags

--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -110,6 +110,9 @@ def document_detail(request, docid):
         )
 
     else:
+        # Add metadata_author or poc if missing
+        document.add_missing_metadata_author_or_poc()
+
         related = get_related_resources(document)
 
         # Update count for popularity ranking,
@@ -361,6 +364,8 @@ def document_metadata(
         )
 
     else:
+        # Add metadata_author or poc if missing
+        document.add_missing_metadata_author_or_poc()
         poc = document.poc
         metadata_author = document.metadata_author
         topic_category = document.category

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -394,6 +394,9 @@ def layer_detail(request, layername, template='layers/layer_detail.html'):
         'base.view_resourcebase',
         _PERMISSION_MSG_VIEW)
 
+    # Add metadata_author or poc if missing
+    layer.add_missing_metadata_author_or_poc()
+
     def decimal_encode(bbox):
         import decimal
         _bbox = []
@@ -859,6 +862,9 @@ def layer_metadata(
     )
 
     topic_category = layer.category
+
+    # Add metadata_author or poc if missing
+    layer.add_missing_metadata_author_or_poc()
 
     poc = layer.poc
     metadata_author = layer.metadata_author

--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -128,6 +128,9 @@ def map_detail(request, mapid, snapshot=None, template='maps/map_detail.html'):
         'base.view_resourcebase',
         _PERMISSION_MSG_VIEW)
 
+    # Add metadata_author or poc if missing
+    map_obj.add_missing_metadata_author_or_poc()
+
     # Update count for popularity ranking,
     # but do not includes admins or resource owners
     if request.user != map_obj.owner and not request.user.is_superuser:
@@ -208,6 +211,8 @@ def map_metadata(
         'base.change_resourcebase_metadata',
         _PERMISSION_MSG_VIEW)
 
+    # Add metadata_author or poc if missing
+    map_obj.add_missing_metadata_author_or_poc()
     poc = map_obj.poc
 
     metadata_author = map_obj.metadata_author


### PR DESCRIPTION
Resources metadata editor and layout broken if poc and/or metadata_author are missing

[Issue #225](https://github.com/geosolutions-it/unesco-ihp/issues/225)

<Include a few sentences describing the overall goals for this Pull Request>

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have trouble with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [x] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [x] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes unless there is an explanation on why the tests are not necessary/implemented
- [ ] This PR passes all existing unit tests (test results will be reported by Travis-ci after opening this PR)
- [ ] This PR passes the QA checks: flake8 geonode
- [ ] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
