### PR TITLE
[Fixes #61] Allow only admins to edit/create keywords

### DIFF
--- a/geonode/base/forms.py
+++ b/geonode/base/forms.py
@@ -411,6 +411,10 @@ class ResourceBaseForm(TranslationModelForm):
                         'data-container': 'body',
                         'data-html': 'true'})
 
+    def disable_keywords_widget_for_non_superuser(self, user):
+        if settings.FREETEXT_KEYWORDS_READONLY and not user.is_superuser:
+            self['keywords'].field.disabled = True
+
     def clean_keywords(self):
         from urllib.parse import unquote
         from html.entities import codepoint2name

--- a/geonode/decorators.py
+++ b/geonode/decorators.py
@@ -202,6 +202,21 @@ def superuser_only(function):
     return _inner
 
 
+def check_keyword_write_perms(function):
+    def _inner(request, *args, **kwargs):
+        keyword_readonly = settings.FREETEXT_KEYWORDS_READONLY and request.method == "POST" \
+                           and not auth.get_user(request).is_superuser
+        request.keyword_readonly = keyword_readonly
+        if keyword_readonly and 'resource-keywords' in request.POST:
+            return HttpResponse(
+                "Unauthorized: Cannot edit/create Free-text Keywords",
+                status=401,
+                content_type="application/json"
+            )
+        return function(request, *args, **kwargs)
+    return _inner
+
+
 def superuser_protected(function):
     """Decorator that forces a view to be accessible by SUPERUSERS only.
     """

--- a/geonode/documents/tests.py
+++ b/geonode/documents/tests.py
@@ -665,3 +665,86 @@ class DocumentResourceLinkTestCase(GeoNodeBaseTestSupport):
                     content_type=ct.id,
                     object_id=resource.id
                 )
+
+
+class DocumentViewTestCase(GeoNodeBaseTestSupport):
+    def setUp(self):
+        self.not_admin = get_user_model().objects.create(username='r-lukaku', is_active=True)
+        self.not_admin.set_password('very-secret')
+        self.not_admin.save()
+        self.test_doc = Document.objects.create(owner=self.not_admin, title='test', is_approved=True)
+
+    def test_that_keyword_multiselect_is_disabled_for_non_admin_users(self):
+        """
+        Test that keyword multiselect widget is disabled when the user is not an admin
+        when FREETEXT_KEYWORDS_READONLY=True
+        """
+        self.client.login(username=self.not_admin.username, password='very-secret')
+        url = reverse('document_metadata', args=(self.test_doc.pk,))
+        with self.settings(FREETEXT_KEYWORDS_READONLY=True):
+            response = self.client.get(url)
+            self.assertFalse(self.not_admin.is_superuser)
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(response.context['form']['keywords'].field.disabled)
+
+    def test_that_keyword_multiselect_is_not_disabled_for_admin_users(self):
+        """
+        Test that only admin users can create/edit keywords
+        """
+        admin = self.not_admin
+        admin.is_superuser = True
+        admin.save()
+        self.client.login(username=admin.username, password='very-secret')
+        url = reverse('document_metadata', args=(self.test_doc.pk,))
+        response = self.client.get(url)
+        self.assertTrue(admin.is_superuser)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context['form']['keywords'].field.disabled)
+
+    def test_that_non_admin_user_can_create_write_to_map_without_keyword(self):
+        """
+        Test that non admin users can write to maps without creating/editing keywords
+        when FREETEXT_KEYWORDS_READONLY=True
+        """
+        self.client.login(username=self.not_admin.username, password='very-secret')
+        url = reverse('document_metadata', args=(self.test_doc.pk,))
+        with self.settings(FREETEXT_KEYWORDS_READONLY=True):
+            response = self.client.post(url)
+            self.assertFalse(self.not_admin.is_superuser)
+            self.assertEqual(response.status_code, 200)
+
+    def test_that_non_admin_user_cannot_create_edit_keyword(self):
+        """
+        Test that non admin users cannot edit/create keywords when FREETEXT_KEYWORDS_READONLY=True
+        """
+        self.client.login(username=self.not_admin.username, password='very-secret')
+        url = reverse('document_metadata', args=(self.test_doc.pk,))
+        with self.settings(FREETEXT_KEYWORDS_READONLY=True):
+            response = self.client.post(url, data={'resource-keywords': 'wonderful-keyword'})
+            self.assertFalse(self.not_admin.is_superuser)
+            self.assertEqual(response.status_code, 401)
+            self.assertEqual(response.content, b'Unauthorized: Cannot edit/create Free-text Keywords')
+
+    def test_that_keyword_multiselect_is_enabled_for_non_admin_users_when_freetext_keywords_readonly_istrue(self):
+        """
+        Test that keyword multiselect widget is not disabled when the user is not an admin
+        and FREETEXT_KEYWORDS_READONLY=False
+        """
+        self.client.login(username=self.not_admin.username, password='very-secret')
+        url = reverse('document_metadata', args=(self.test_doc.pk,))
+        with self.settings(FREETEXT_KEYWORDS_READONLY=False):
+            response = self.client.get(url)
+            self.assertFalse(self.not_admin.is_superuser)
+            self.assertEqual(response.status_code, 200)
+            self.assertFalse(response.context['form']['keywords'].field.disabled)
+
+    def test_that_non_admin_user_can_create_edit_keyword_when_freetext_keywords_readonly_istrue(self):
+        """
+        Test that non admin users can edit/create keywords when FREETEXT_KEYWORDS_READONLY=False
+        """
+        self.client.login(username=self.not_admin.username, password='very-secret')
+        url = reverse('document_metadata', args=(self.test_doc.pk,))
+        with self.settings(FREETEXT_KEYWORDS_READONLY=False):
+            response = self.client.post(url, data={'resource-keywords': 'wonderful-keyword'})
+            self.assertFalse(self.not_admin.is_superuser)
+            self.assertEqual(response.status_code, 200)

--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -39,6 +39,7 @@ from django.db.models import F
 from django.forms.utils import ErrorList
 
 from geonode.base.utils import ManageResourceOwnerPermissions
+from geonode.decorators import check_keyword_write_perms
 from geonode.utils import resolve_object
 from geonode.security.views import _perms_info_json
 from geonode.people.forms import ProfileForm
@@ -345,6 +346,7 @@ class DocumentUpdateView(UpdateView):
 
 
 @login_required
+@check_keyword_write_perms
 def document_metadata(
         request,
         docid,
@@ -383,6 +385,7 @@ def document_metadata(
         poc = document.poc
         metadata_author = document.metadata_author
         topic_category = document.category
+        current_keywords = [keyword.name for keyword in document.keywords.all()]
 
         if request.method == "POST":
             document_form = DocumentForm(
@@ -395,6 +398,7 @@ def document_metadata(
             tkeywords_form = TKeywordForm(request.POST)
         else:
             document_form = DocumentForm(instance=document, prefix="resource")
+            document_form.disable_keywords_widget_for_non_superuser(request.user)
             category_form = CategoryForm(
                 prefix="category_choice_field",
                 initial=topic_category.id if topic_category else None)
@@ -428,7 +432,7 @@ def document_metadata(
         ) and category_form.is_valid():
             new_poc = document_form.cleaned_data['poc']
             new_author = document_form.cleaned_data['metadata_author']
-            new_keywords = document_form.cleaned_data['keywords']
+            new_keywords = current_keywords if request.keyword_readonly else document_form.cleaned_data['keywords']
             new_regions = document_form.cleaned_data['regions']
 
             new_category = None

--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -44,6 +44,7 @@ from django.utils.html import strip_tags
 from django.db.models import F
 from django.views.decorators.clickjacking import (xframe_options_exempt,
                                                   xframe_options_sameorigin)
+from geonode.decorators import check_keyword_write_perms
 from geonode.layers.models import Layer
 from geonode.maps.models import Map, MapLayer, MapSnapshot
 from geonode.layers.views import _resolve_layer
@@ -210,6 +211,7 @@ def map_detail(request, mapid, snapshot=None, template='maps/map_detail.html'):
 
 
 @login_required
+@check_keyword_write_perms
 def map_metadata(
         request,
         mapid,
@@ -223,6 +225,7 @@ def map_metadata(
 
     # Add metadata_author or poc if missing
     map_obj.add_missing_metadata_author_or_poc()
+    current_keywords = [keyword.name for keyword in map_obj.keywords.all()]
     poc = map_obj.poc
 
     metadata_author = map_obj.metadata_author
@@ -237,6 +240,7 @@ def map_metadata(
         tkeywords_form = TKeywordForm(request.POST)
     else:
         map_form = MapForm(instance=map_obj, prefix="resource")
+        map_form.disable_keywords_widget_for_non_superuser(request.user)
         category_form = CategoryForm(
             prefix="category_choice_field",
             initial=topic_category.id if topic_category else None)
@@ -270,7 +274,7 @@ def map_metadata(
     ) and category_form.is_valid():
         new_poc = map_form.cleaned_data['poc']
         new_author = map_form.cleaned_data['metadata_author']
-        new_keywords = map_form.cleaned_data['keywords']
+        new_keywords = current_keywords if request.keyword_readonly else map_form.cleaned_data['keywords']
         new_regions = map_form.cleaned_data['regions']
         new_title = strip_tags(map_form.cleaned_data['title'])
         new_abstract = strip_tags(map_form.cleaned_data['abstract'])


### PR DESCRIPTION
Allow only admins to edit/create keywords

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

For all pull requests:

- [x] Confirm you have read the [contribution guidelines](https://github.com/GeoNode/geonode/blob/master/CONTRIBUTING.md) 
- [x] You have sent a Contribution Licence Agreement (CLA) as necessary (not required for small changes, e.g., fixing typos in the documentation)
- [x] Make sure the first PR targets the master branch, eventual backports will be managed later. This can be ignored if the PR is fixing an issue that only happens in a specific branch, but not in newer ones.

The following are required only for core and extension modules (they are welcomed, but not required, for contrib modules):
- [ ] There is a ticket in https://github.com/GeoNode/geonode/issues describing the issue/improvement/feature (a notable exemption is, changes not visible to end-users)
- [ ] The issue connected to the PR must have Labels and Milestone assigned
- [x] PR for bug fixes and small new features are presented as a single commit
- [x] Commit message must be in the form "[Fixes #<issue_number>] Title of the Issue"
- [x] New unit tests have been added covering the changes, unless there is an explanation on why the tests are not necessary/implemented
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] This PR passes the QA checks: flake8 geonode
- [x] Commits changing the **settings**, **UI**, **existing user workflows**, or adding **new functionality**, need to include documentation updates

**Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or inapplicable.**
